### PR TITLE
Support all teamtailor buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Teamtailor notes
 
 This is a mirrored version of the original repository. In order to get the implementation to work with s3 we've changed the source code and whitelisted a couple of our domains.
-After doing changes in this repo, run `npm install` then `./node_modules/.bin/gulp minified` command and copy the minified files from `/build/minified/` into the Teamtailor repository.
+After doing changes in this repo, run `npm install` then `npx gulp minified` command and to deploy the changes you can use the aws cli like this `aws s3 sync build/minified s3://scripts.teamtailor-cdn.com/pdf.js/v5 --acl public-read`, just remember to increment the version number to bust the cache.
 
 # PDF.js [![Build Status](https://travis-ci.org/mozilla/pdf.js.svg?branch=master)](https://travis-ci.org/mozilla/pdf.js)
 
@@ -16,11 +16,11 @@ rendering PDFs.
 PDF.js is an open source project and always looking for more contributors. To
 get involved, visit:
 
-+ [Issue Reporting Guide](https://github.com/mozilla/pdf.js/blob/master/.github/CONTRIBUTING.md)
-+ [Code Contribution Guide](https://github.com/mozilla/pdf.js/wiki/Contributing)
-+ [Frequently Asked Questions](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions)
-+ [Good Beginner Bugs](https://github.com/mozilla/pdf.js/issues?direction=desc&labels=good-beginner-bug&page=1&sort=created&state=open)
-+ [Projects](https://github.com/mozilla/pdf.js/projects)
+- [Issue Reporting Guide](https://github.com/mozilla/pdf.js/blob/master/.github/CONTRIBUTING.md)
+- [Code Contribution Guide](https://github.com/mozilla/pdf.js/wiki/Contributing)
+- [Frequently Asked Questions](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions)
+- [Good Beginner Bugs](https://github.com/mozilla/pdf.js/issues?direction=desc&labels=good-beginner-bug&page=1&sort=created&state=open)
+- [Projects](https://github.com/mozilla/pdf.js/projects)
 
 Feel free to stop by our [Matrix room](https://chat.mozilla.org/#/room/#pdfjs:mozilla.org) for questions or guidance.
 
@@ -32,9 +32,9 @@ Please note that the "Modern browsers" version assumes native support for
 features such as optional chaining, nullish coalescing,
 and private `class` fields/methods.
 
-+ Modern browsers: https://mozilla.github.io/pdf.js/web/viewer.html
+- Modern browsers: https://mozilla.github.io/pdf.js/web/viewer.html
 
-+ Older browsers: https://mozilla.github.io/pdf.js/legacy/web/viewer.html
+- Older browsers: https://mozilla.github.io/pdf.js/legacy/web/viewer.html
 
 ### Browser Extensions
 
@@ -141,7 +141,7 @@ Check out our FAQs and get answers to common questions:
 
 Talk to us on Matrix:
 
-+ https://chat.mozilla.org/#/room/#pdfjs:mozilla.org
+- https://chat.mozilla.org/#/room/#pdfjs:mozilla.org
 
 File an issue:
 

--- a/web/app.js
+++ b/web/app.js
@@ -2216,7 +2216,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   const SAFE_HOSTED_VIEWER_ORIGINS = ["null", ".teamtailor.localhost"];
 
   const TEAMTAILOR_S3_BUCKET_REG_EX =
-    /^https:\/\/teamtailor-[\w-]+.s3.[\w-]+.amazonaws.com$/;
+    /^https:\/\/teamtailor-[\w-]+\.s3\.[\w-]+\.amazonaws\.com$/;
 
   validateFileURL = function validateFileURL(file) {
     if (file === undefined) {

--- a/web/app.js
+++ b/web/app.js
@@ -2218,12 +2218,7 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
     '.teamtailor.localhost',
   ];
 
-  const S3_BUCKETS = [
-    'teamtailor-production',
-    'teamtailor-staging',
-    'teamtailor-swedbank',
-    'teamtailor-lmfr',
-  ];
+  const TEAMTAILOR_S3_BUCKET_REG_EX = /^https:\/\/teamtailor-\w+.s3.[\w-]+.amazonaws.com$/;
 
   validateFileURL = function validateFileURL(file) {
     if (file === undefined) {
@@ -2244,10 +2239,7 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
         return;
       }
 
-      let fileOriginMatches = function(allowedBucket) {
-        return origin === 'https://' + allowedBucket + '.s3.eu-west-1.amazonaws.com';
-      };
-      if (S3_BUCKETS.some(fileOriginMatches)) {
+      if (TEAMTAILOR_S3_BUCKET_REG_EX.exec(origin)) {
         return;
       }
 

--- a/web/app.js
+++ b/web/app.js
@@ -2212,13 +2212,11 @@ const PDFViewerApplication = {
 };
 
 let validateFileURL;
-if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-  const SAFE_HOSTED_VIEWER_ORIGINS = [
-    'null',
-    '.teamtailor.localhost',
-  ];
+if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+  const SAFE_HOSTED_VIEWER_ORIGINS = ["null", ".teamtailor.localhost"];
 
-  const TEAMTAILOR_S3_BUCKET_REG_EX = /^https:\/\/teamtailor-\w+.s3.[\w-]+.amazonaws.com$/;
+  const TEAMTAILOR_S3_BUCKET_REG_EX =
+    /^https:\/\/teamtailor-[\w-]+.s3.[\w-]+.amazonaws.com$/;
 
   validateFileURL = function validateFileURL(file) {
     if (file === undefined) {
@@ -2227,12 +2225,14 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
     try {
       const viewerOrigin = new URL(window.location.href).origin || "null";
 
-      let originMatches = function(allowedOrigin) {
-        return allowedOrigin.includes(viewerOrigin) ||
-          viewerOrigin.endsWith(allowedOrigin);
+      const originMatches = function (allowedOrigin) {
+        return (
+          allowedOrigin.includes(viewerOrigin) ||
+          viewerOrigin.endsWith(allowedOrigin)
+        );
       };
 
-      let { origin, protocol, } = new URL(file, window.location.href);
+      const { origin, protocol } = new URL(file, window.location.href);
 
       if (SAFE_HOSTED_VIEWER_ORIGINS.some(originMatches)) {
         // Local viewer, allow for any file locations

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -251,7 +251,12 @@ function webViewerLoad() {
         // Attempt to dispatch the event at the embedding `document`,
         // in order to support cases where the viewer is embedded in
         // a *dynamically* created <iframe> element.
-        parent.document.dispatchEvent(event);
+        //
+        //
+        // Disable parent document events to avoid cross origin issues now when
+        // we (Teamtailor) are hosting the pdf viewer on a different domain.
+        //
+        // parent.document.dispatchEvent(event);
       } catch (ex) {
         // The viewer could be in e.g. a cross-origin <iframe> element,
         // fallback to dispatching the event at the current `document`.


### PR DESCRIPTION
* Avoid adding new stack's buckets to the allow list by allow reading pdfs from all S3 buckets prefixed with `teamtailor-`.
* Small fix to get rid of warning when hosting this on an other domain than the app.
* Deploy instructions for how to upload it to S3 instead of adding all fils to the main tt repo.
* based on #20 which upgrades the pdf.js code to the latest version